### PR TITLE
Turnos

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,53 @@
  *= require_tree .
  *= require_self
  */
+
+body {
+  margin: 0;
+  padding: 0;
+}
+ul {
+  list-style: outside none none;
+}
+li {
+  border-style: solid;
+  border-color: #DDDDDD;
+  border-width: 1px;
+  padding: 0;
+  vertical-align: top;
+  width: 14%;
+  float: left;
+  min-height: 125px;
+}
+li h1 {
+  font-size: 1em;
+  margin: 0;
+  text-align: center;
+  border-bottom: 1px solid #dddddd;
+}
+li h2 {
+  font-size: 1em;
+  text-align: right;
+  padding-right: 3px;
+  margin: 0;
+}
+li .actions {
+  text-align: center;
+  margin: 0;
+}
+li .btn-group {
+  width: 100%;
+  padding: 5px;
+}
+li .btn {
+  width: 50%;
+}
+
+li p {
+  font-size: 0.9em;
+  padding-left: 5px;
+}
+li.inactive {
+  opacity: 0.7;
+  background-color: #EAE9E6;
+}

--- a/app/controllers/turns_controller.rb
+++ b/app/controllers/turns_controller.rb
@@ -1,0 +1,5 @@
+class TurnsController < ApplicationController
+  def index
+    @current_week = TurnBuilder.build(Calendar.new.build_week)
+  end
+end

--- a/app/models/calendar.rb
+++ b/app/models/calendar.rb
@@ -1,0 +1,19 @@
+class Calendar
+  extend Forwardable
+
+  def_delegators :@at, :at_beginning_of_week
+
+  def initialize(at = Time.now.to_date)
+    @at = at
+  end
+
+  def build_week
+    week.to_a
+  end
+
+  private
+
+  def week
+    (at_beginning_of_week ... at_beginning_of_week + 7.days)
+  end
+end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -1,0 +1,5 @@
+class Turn < ActiveRecord::Base
+  has_many :visit
+
+  delegate :zones, to: :visit
+end

--- a/app/models/turn_builder.rb
+++ b/app/models/turn_builder.rb
@@ -1,0 +1,30 @@
+class TurnBuilder
+
+  def self.build(days)
+    days.map { |day| new(day).build }
+  end
+
+  def initialize(at)
+    @at = at
+  end
+
+  def expired?
+    @at < Time.now.to_date
+  end
+
+  def new?
+    !turn
+  end
+
+  def build
+    return Turns::Expired.new(@at) if expired?
+    return Turns::New.new(@at) if new?
+    Turns::Active.new(turn)
+  end
+
+  private
+
+  def turn
+    Turn.where(at: @at).first
+  end
+end

--- a/app/models/turns/active.rb
+++ b/app/models/turns/active.rb
@@ -1,0 +1,15 @@
+class Turns::Active
+  extend Forwardable
+
+  def_delegators :turn, :at
+
+  attr_accessor :turn
+
+  def initialize(turn)
+    self.turn = turn
+  end
+
+  def to_partial_path
+    'turns/active'
+  end
+end

--- a/app/models/turns/expired.rb
+++ b/app/models/turns/expired.rb
@@ -1,0 +1,11 @@
+class Turns::Expired
+  attr_accessor :at
+
+  def initialize(at)
+    self.at = at
+  end
+
+  def to_partial_path
+    'turns/expired'
+  end
+end

--- a/app/models/turns/new.rb
+++ b/app/models/turns/new.rb
@@ -1,0 +1,11 @@
+class Turns::New
+  attr_accessor :at
+
+  def initialize(at)
+    self.at = at
+  end
+
+  def to_partial_path
+    'turns/new'
+  end
+end

--- a/app/views/turns/_active.html.erb
+++ b/app/views/turns/_active.html.erb
@@ -1,0 +1,14 @@
+<li>
+  <h1><%= turn.at.strftime('%a') %></h1>
+  <h2><%= turn.at.strftime('%d') %></h2>
+
+  <p>Roberto, 3 tareas</p>
+  <p>
+  <span class="label label-info">sur</span>
+  <span class="label label-info">centro</span>
+  </p>
+  <div class="btn-group btn-group-xs" role="group" aria-label="...">
+    <button type="button" class="btn btn-primary">Elegir</button>
+    <button type="button" class="btn btn-default">Detalles</button>
+  </div>
+</li>

--- a/app/views/turns/_expired.html.erb
+++ b/app/views/turns/_expired.html.erb
@@ -1,0 +1,4 @@
+<li class='inactive'>
+  <h1><%= turn.at.strftime('%a') %></h1>
+  <h2><%= turn.at.strftime('%d') %></h2>
+</li>

--- a/app/views/turns/_new.html.erb
+++ b/app/views/turns/_new.html.erb
@@ -1,0 +1,7 @@
+<li>
+  <h1><%= turn.at.strftime('%a') %></h1>
+  <h2><%= turn.at.strftime('%d') %></h2>
+  <div class="btn-group btn-group-xs" role="group" aria-label="...">
+    <button type="button" class="btn btn-primary">Crear Turno</button>
+  </div>
+</li>

--- a/app/views/turns/index.html.erb
+++ b/app/views/turns/index.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% @current_week.each do |turn| %>
+    <%= render partial: turn, locals: { turn: turn } %>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,6 @@ Rails.application.routes.draw do
   end
 
   resources :visits, only: [:create]
+
+  resources :turns
 end

--- a/db/migrate/20160208182847_create_turns.rb
+++ b/db/migrate/20160208182847_create_turns.rb
@@ -1,0 +1,12 @@
+class CreateTurns < ActiveRecord::Migration
+  def change
+    create_table :turns do |t|
+      t.date :at
+      t.belongs_to :employee, index: true, foreign_key: true
+
+      t.timestamps null: false
+    end
+
+    add_column :visits, :turn_id, :integer, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160203205059) do
+ActiveRecord::Schema.define(version: 20160208182847) do
 
   create_table "clients", force: :cascade do |t|
     t.string   "dni",        null: false
@@ -25,6 +25,15 @@ ActiveRecord::Schema.define(version: 20160203205059) do
   end
 
   add_index "clients", ["dni"], name: "index_clients_on_dni"
+
+  create_table "turns", force: :cascade do |t|
+    t.date     "at"
+    t.integer  "employee_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "turns", ["employee_id"], name: "index_turns_on_employee_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",           null: false
@@ -41,6 +50,7 @@ ActiveRecord::Schema.define(version: 20160203205059) do
     t.integer  "client_id"
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.integer  "turn_id"
   end
 
   add_index "visits", ["client_id"], name: "index_visits_on_client_id"

--- a/test/controllers/turns_controller_test.rb
+++ b/test/controllers/turns_controller_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class TurnsControllerTest < ActionController::TestCase
+  test 'should get index' do
+    get :index
+    assert_response :success
+  end
+end

--- a/test/models/calendar_test.rb
+++ b/test/models/calendar_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class CalendarTest < ActiveSupport::TestCase
+
+  def at
+    Date.new 2016, 2, 9
+  end
+
+  def calendar
+    Calendar.new(at)
+  end
+
+  test 'build_week' do
+    assert calendar.build_week.class == Array
+  end
+
+  test 'the first value is the first day of the week' do
+    assert calendar.build_week.first == at.at_beginning_of_week
+  end
+end

--- a/test/models/turn_builder_test.rb
+++ b/test/models/turn_builder_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+require 'minitest/mock'
+
+class TurnDecoratorTest < ActiveSupport::TestCase
+  def at
+    Time.new(2016, 2, 9)
+  end
+
+  def turn
+    @turn ||= TurnBuilder.new(at)
+  end
+
+  test 'a turn is expired when the date is already in the past' do
+    Time.stub(:now, Time.new(2016, 2, 10)) do
+      assert turn.expired?
+    end
+  end
+
+  test 'a turn is a new one is there is no visit on that day' do
+    Turn.stub(:where, []) do
+      assert turn.new?
+    end
+  end
+
+  test 'build should return an active turn instance when the turn exists' do
+    turn.stub(:expired?, false) do
+      turn.stub(:new?, false) do
+        assert turn.build.class == Turns::Active
+      end
+    end
+  end
+
+  test 'build should return an expired turn instance for expired turns' do
+    turn.stub(:expired?, true) do
+      assert turn.build.class == Turns::Expired
+    end
+  end
+
+  test 'build should return a new turn instance when the turn dont exists' do
+    turn.stub(:expired?, false) do
+      turn.stub(:new?, true) do
+        assert turn.build.class == Turns::New
+      end
+    end
+  end
+
+  test 'should create an array of turns for an array of dates' do
+    today = Time.now.to_date
+    tomorrow = today + 1.days
+    days = (today ... tomorrow)
+    turn_builder = TurnBuilder.build days
+    assert turn_builder.class == Array
+    assert turn_builder.first.class.name.include? 'Turns'
+    assert turn_builder.last.class.name.include? 'Turns'
+  end
+end


### PR DESCRIPTION
Estos cambios crean una vista en /turns que muestra los turnos durante la actual semana, dependiendo de los 3 estados posibles que puede tener cada día.
expirado: que ya pasó
activo: ya se creo el turno y muestra los datos para este
nuevo: que todavía no se creo nada para este día.

@noili fijate lo que hice acá, es un poco complejo, pero me gusta como quedó, @eloyesp estoy seguro que vas a encontrar como hacerlo más simple.
