### PR TITLE
Create turn and visit together

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 
+gem 'rails-i18n', '~> 4.0'
+
 # Use Unicorn as the app server
 # gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
+    rails-i18n (4.0.8)
+      i18n (~> 0.7)
+      railties (~> 4.0)
     railties (4.2.5)
       actionpack (= 4.2.5)
       activesupport (= 4.2.5)
@@ -173,6 +176,7 @@ DEPENDENCIES
   jquery-rails
   pry
   rails (= 4.2.5)
+  rails-i18n (~> 4.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](http://img.shields.io/travis/bluelemons/muebleria.svg)](https://travis-ci.org/bluelemons/muebleria)
+[![Build Status](https://img.shields.io/codeship/7c7644e0-bb13-0133-1f3d-4635c7e75c57.svg)](https://codeship.com/projects/135777)
 [![Code Climate](http://img.shields.io/codeclimate/github/bluelemons/muebleria.svg)](https://codeclimate.com/github/bluelemons/muebleria)
 [![Dependency Status](http://img.shields.io/gemnasium/bluelemons/muebleria.svg)](https://gemnasium.com/bluelemons/muebleria)
 [![Test Coverage](https://codeclimate.com/github/bluelemons/muebleria/badges/coverage.svg)](https://codeclimate.com/github/bluelemons/muebleria)

--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -1,0 +1,14 @@
+$(document)
+  .on('click', '.calendar button[data-turn-id]', function (evt) {
+    $('#visit_turn_id').val($(this).data('turn-id'));
+    $('#turn_at').val('');
+    $('fieldset#new-turn').hide();
+    $('fieldset#add-to-turn').show();
+  })
+  .on('click', '.calendar button.new-turn[data-at]', function (evt) {
+    $('#turn_at').val($(this).data('at'));
+    $('#turn_employee_id').focus();
+    $('#visit_turn_id').val('');
+    $('fieldset#add-to-turn').hide();
+    $('fieldset#new-turn').show();
+  });

--- a/app/assets/javascripts/calendar.js
+++ b/app/assets/javascripts/calendar.js
@@ -6,8 +6,8 @@ $(document)
     $('fieldset#add-to-turn').show();
   })
   .on('click', '.calendar button.new-turn[data-at]', function (evt) {
-    $('#turn_at').val($(this).data('at'));
-    $('#turn_employee_id').focus();
+    $('#visit_turn_attributes_at').val($(this).data('at'));
+    $('#visit_turn_attributes_employee_id').focus();
     $('#visit_turn_id').val('');
     $('fieldset#add-to-turn').hide();
     $('fieldset#new-turn').show();

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -8,7 +8,7 @@ class VisitsController < ApplicationController
   end
 
   def create
-    visit = client.visits.create(visit_params)
+    visit = client.visits.create!(visit_params)
     redirect_to visit_path(visit)
   end
 

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -1,4 +1,6 @@
 class VisitsController < ApplicationController
+  before_action :set_visit, only: [:show]
+
   def index
   end
 
@@ -7,15 +9,28 @@ class VisitsController < ApplicationController
     @calendar = Day.build 2
   end
 
+  # Create a new visit and create a new turn for it when details are given
   def create
-    visit = client.visits.create!(visit_params)
-    redirect_to visit_path(visit)
+    @visit = client.visits.new(visit_params)
+    Visit.transaction do
+      @visit.turn = Turn.create! turn_params if visit_params['turn_id'].empty?
+      @visit.save!
+    end
+    redirect_to visit_path(@visit)
   end
 
   private
 
+  def set_visit
+    @visit = Visit.find(params[:id])
+  end
+
   def visit_params
     params.require(:visit).permit(:description, :duration, :client, :turn_id)
+  end
+
+  def turn_params
+    params.require(:turn).permit(:at, :employee_id)
   end
 
   def client

--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -4,7 +4,7 @@ class VisitsController < ApplicationController
 
   def new
     @visit = client.visits.new
-    @calendar = Day.build
+    @calendar = Day.build 2
   end
 
   def create

--- a/app/models/day.rb
+++ b/app/models/day.rb
@@ -17,9 +17,10 @@ class Day
     Turn.where(at: date)
   end
 
-  def self.build
+  def self.build weeks = 1
     at_beginning_of_week = Time.now.to_date.at_beginning_of_week
-    (at_beginning_of_week ... at_beginning_of_week + 7.days).map do |date|
+    days = (weeks * 7).days
+    (at_beginning_of_week ... at_beginning_of_week + days).map do |date|
       new date
     end
   end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -1,3 +1,7 @@
 class Employee < ActiveRecord::Base
   validates :name, presence: true
+
+  def to_s
+    name
+  end
 end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -12,7 +12,14 @@ class Turn < ActiveRecord::Base
 
   validates :at, presence: true, future: { on: :create }
 
+  scope :available, -> { where('at >= ?', Date.today) }
+
   def zones
     ['sur', 'norte']
+  end
+
+  def to_s
+    date = I18n.localize at, format: :short
+    "#{ date } (#{ employee })"
   end
 end

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -1,6 +1,16 @@
 class Turn < ActiveRecord::Base
-  belongs_to :employee
+
+  class FutureValidator < ActiveModel::EachValidator
+    def validate_each record, attribute, value
+      record.errors.add attribute, 'no puede ser una fecha pasada' if
+        value && value.past?
+    end
+  end
+
+  belongs_to :employee, required: true
   has_many :visits
+
+  validates :at, presence: true, future: { on: :create }
 
   def zones
     ['sur', 'norte']

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -1,3 +1,4 @@
 class Visit < ActiveRecord::Base
-  belongs_to :client
+  belongs_to :client, required: true
+  belongs_to :turn, required: true
 end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -1,4 +1,10 @@
 class Visit < ActiveRecord::Base
   belongs_to :client, required: true
   belongs_to :turn, required: true
+
+  validates :turn, presence: true
+
+  accepts_nested_attributes_for :turn
+
+  after_initialize { self.turn ||= Turn.new }
 end

--- a/app/views/days/_day.html.erb
+++ b/app/views/days/_day.html.erb
@@ -3,18 +3,14 @@
   <h2><%= day.date.strftime('%d') %></h2>
 
   <% day.turns.each do |turn|%>
-    <p><%= turn.employee %>, <%= turn.visits.count %> tareas</p>
-    <p>
-    <% turn.zones.each do |zone| %>
-      <span class="label label-info"><%= zone %></span>
-    <% end %>
-    </p>
-    <div class="radio">
-      <label>
-        <input type="radio" name="visit[turn_id]" id="visit[turn_id]"
-          value=<%= turn.id %>>
-      </label>
-    </div>
+    <button class="btn btn-default btn-block" type="button" id="turn-#{ turn.id }">
+      <p><%= turn.employee %>, <%= turn.visits.count %> tareas</p>
+      <p>
+      <% turn.zones.each do |zone| %>
+        <span class="label label-info"><%= zone %></span>
+      <% end %>
+      </p>
+    </button>
   <% end %>
   <% unless day.expired? %>
     <% if day.turns.empty? %>

--- a/app/views/days/_day.html.erb
+++ b/app/views/days/_day.html.erb
@@ -3,7 +3,7 @@
   <h2><%= day.date.strftime('%d') %></h2>
 
   <% day.turns.each do |turn|%>
-    <button class="btn btn-default btn-block" type="button" id="turn-#{ turn.id }">
+    <button class="btn btn-default btn-block" type="button" data-turn-id="<%= turn.id %>">
       <p><%= turn.employee %>, <%= turn.visits.count %> tareas</p>
       <p>
       <% turn.zones.each do |zone| %>
@@ -13,9 +13,9 @@
     </button>
   <% end %>
   <% unless day.expired? %>
-    <% if day.turns.empty? %>
-      <%# <%= render partial: 'turns/form', locals: { turn: day.turns.new }%>
-    <% else %>
-    <% end %>
+    <button type="button" class="btn btn-primary btn-block new-turn"
+            data-at="<%= day.date %>">
+      Nuevo turno
+    </button>
   <% end %>
 </li>

--- a/app/views/turns/_form.html.erb
+++ b/app/views/turns/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for turn do |f| %>
+<%= form_for @turn do |f| %>
   <%= f.text_field :at, hidden: true %>
   <%= f.submit 'Crear Turno', class: 'btn btn-primary' %>
 <% end %>

--- a/app/views/visits/new.html.erb
+++ b/app/views/visits/new.html.erb
@@ -1,4 +1,15 @@
 <%= form_for [:client, @visit] do |f| %>
+  <% if @visit.errors.any? %>
+    <div id="error_explanation">
+      <h2>Verifique los datos ingresados:</h2>
+
+      <ul>
+        <% @visit.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
   <div class="form-group">
     <label>Descripción</label>
     <%= f.text_area :description,
@@ -27,7 +38,7 @@
   </fieldset>
   <fieldset id="new-turn">
     <legend>Nuevo turno</legend>
-    <%= fields_for :turn do |tf| %>
+    <%= f.fields_for :turn do |tf| %>
       <div class="form-group">
         <%= tf.label :at, 'Fecha' %>
         <%= tf.text_field :at, class: 'form-control' %>

--- a/app/views/visits/new.html.erb
+++ b/app/views/visits/new.html.erb
@@ -13,8 +13,13 @@
       placeholder: 'Cuantas horas puede demorar?',
       class: 'form-control'%>
   </div>
+  <div class="form-group">
+    <%= f.label :turn_id, 'Salida' %>
+    <%= f.select :turn_id, Turn.available.map { |t| [t.to_s, t.id] },
+      {}, class: 'form-control' %>
+  </div>
   <ul class="calendar">
-    <%= render @calendar, locals: { f: f } %>
+    <%= render @calendar %>
   </ul>
   <%= f.submit 'Guardar', class: 'btn btn-lg btn-primary btn-block' %>
 <% end %>

--- a/app/views/visits/new.html.erb
+++ b/app/views/visits/new.html.erb
@@ -13,13 +13,29 @@
       placeholder: 'Cuantas horas puede demorar?',
       class: 'form-control'%>
   </div>
-  <div class="form-group">
-    <%= f.label :turn_id, 'Salida' %>
-    <%= f.select :turn_id, Turn.available.map { |t| [t.to_s, t.id] },
-      {}, class: 'form-control' %>
-  </div>
-  <ul class="calendar">
-    <%= render @calendar %>
-  </ul>
+  <fieldset>
+    <legend>Agendar</legend>
+    <ul class="calendar">
+      <%= render @calendar %>
+    </ul>
+    <div class="form-group">
+      <%= f.label :turn_id, 'Turno existente' %>
+      <%= f.select :turn_id, Turn.available.map { |t| [t.to_s, t.id] },
+        { prompt: 'Seleccione un turno' },
+        class: 'form-control' %>
+    </div>
+    <legend>Nuevo turno</legend>
+    <%= fields_for :turn do |tf| %>
+      <div class="form-group">
+        <%= tf.label :at, 'Fecha' %>
+        <%= tf.text_field :at, class: 'form-control' %>
+      </div>
+      <div class="form-group">
+        <%= tf.label :employee %>
+        <%= tf.select :employee, Employee.all.map { |t| [t, t.id] },
+          { prompt: 'Seleccione armador' }, class: 'form-control' %>
+      </div>
+    <% end %>
+  </fieldset>
   <%= f.submit 'Guardar', class: 'btn btn-lg btn-primary btn-block' %>
 <% end %>

--- a/app/views/visits/new.html.erb
+++ b/app/views/visits/new.html.erb
@@ -13,17 +13,19 @@
       placeholder: 'Cuantas horas puede demorar?',
       class: 'form-control'%>
   </div>
-  <fieldset>
-    <legend>Agendar</legend>
-    <ul class="calendar">
+  <legend>Agendar</legend>
+    <ul class="calendar clearfix">
       <%= render @calendar %>
     </ul>
+  <fieldset id="add-to-turn">
     <div class="form-group">
-      <%= f.label :turn_id, 'Turno existente' %>
+      <%= f.label :turn_id, 'Turno' %>
       <%= f.select :turn_id, Turn.available.map { |t| [t.to_s, t.id] },
         { prompt: 'Seleccione un turno' },
         class: 'form-control' %>
     </div>
+  </fieldset>
+  <fieldset id="new-turn">
     <legend>Nuevo turno</legend>
     <%= fields_for :turn do |tf| %>
       <div class="form-group">
@@ -31,8 +33,8 @@
         <%= tf.text_field :at, class: 'form-control' %>
       </div>
       <div class="form-group">
-        <%= tf.label :employee %>
-        <%= tf.select :employee, Employee.all.map { |t| [t, t.id] },
+        <%= tf.label :employee_id %>
+        <%= tf.select :employee_id, Employee.all.map { |t| [t, t.id] },
           { prompt: 'Seleccione armador' }, class: 'form-control' %>
       </div>
     <% end %>

--- a/app/views/visits/show.html.erb
+++ b/app/views/visits/show.html.erb
@@ -1,0 +1,1 @@
+<%= @visit.inspect %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,11 +14,10 @@ module Muebleria
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Buenos Aires'
 
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
+    config.i18n.default_locale = :es
+    config.i18n.available_locales = :es
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,6 @@
+es:
+  activerecord:
+    models:
+      turn:
+        one: Turno
+        other: Turnos

--- a/test/controllers/turns_controller_test.rb
+++ b/test/controllers/turns_controller_test.rb
@@ -2,12 +2,12 @@ require 'test_helper'
 
 class TurnsControllerTest < ActionController::TestCase
   setup do
-    @turn = turns(:one)
+    @turn = turns(:jueves)
   end
 
   test "should create turn" do
     assert_difference('Turn.count') do
-      post :create, turn: { at: @turn.at }
+      post :create, turn: { at: Date.tomorrow, employee_id: employees(:pablo) }
     end
 
     assert_redirected_to turn_path(assigns(:turn))

--- a/test/controllers/visits_controller_test.rb
+++ b/test/controllers/visits_controller_test.rb
@@ -5,29 +5,30 @@ class VisitsControllerTest < ActionController::TestCase
     clients(:john)
   end
 
-  def valid_visit_data
-    { description: '2 camas',
-      duration: '2',
-      turn_id: turns(:jueves) }
-  end
-
   test 'the visit new form' do
     get :new, client_dni: client.dni
     assert_not_nil assigns(:visit)
     assert_response :success
   end
 
-  test '#new show form for new visit' do
-    get :new, client_dni: client.dni
-    assert_select 'textarea#visit_description'
-    assert_select 'input#visit_duration'
-    assert_select 'input[type=submit]'
+  test 'should create visit selecting an existing turn' do
+    assert_difference('Visit.count') do
+      post :create, client_dni: client.dni,
+                    visit: { description: '2 camas',
+                             duration: '2',
+                             turn_id: turns(:jueves) }
+      assert_redirected_to visit_path(Visit.last)
+    end
   end
 
-  test 'should create visit' do
-    assert_difference('Visit.count') do
-      post :create, visit: valid_visit_data, client_dni: client.dni
-
+  test 'should create visit with a new turn' do
+    assert_difference(['Visit.count', 'Turn.count']) do
+      post :create, client_dni: client.dni,
+        visit: { description: '2 camas',
+                 duration: '2',
+                 turn_id: '' },
+        turn: { at: Date.tomorrow,
+                employee_id: employees(:pablo) }
       assert_redirected_to visit_path(Visit.last)
     end
   end

--- a/test/controllers/visits_controller_test.rb
+++ b/test/controllers/visits_controller_test.rb
@@ -6,7 +6,9 @@ class VisitsControllerTest < ActionController::TestCase
   end
 
   def valid_visit_data
-    { visit: { description: '2 camas', duration: '2', client: client } }
+    { description: '2 camas',
+      duration: '2',
+      turn_id: turns(:jueves) }
   end
 
   test 'the visit new form' do

--- a/test/controllers/visits_controller_test.rb
+++ b/test/controllers/visits_controller_test.rb
@@ -26,9 +26,9 @@ class VisitsControllerTest < ActionController::TestCase
       post :create, client_dni: client.dni,
         visit: { description: '2 camas',
                  duration: '2',
-                 turn_id: '' },
-        turn: { at: Date.tomorrow,
-                employee_id: employees(:pablo) }
+                 turn_attributes: {
+                   at: Date.tomorrow,
+                   employee_id: employees(:pablo) } }
       assert_redirected_to visit_path(Visit.last)
     end
   end

--- a/test/fixtures/turns.yml
+++ b/test/fixtures/turns.yml
@@ -1,2 +1,4 @@
-one:
-  at: '2016-01-01'
+# hay un turno el siguiente jueves
+jueves:
+  at: <%= Date.parse 'thusday' %>
+  employee: pablo

--- a/test/integration/admin_flow_test.rb
+++ b/test/integration/admin_flow_test.rb
@@ -27,6 +27,7 @@ class AdminFlowTest < ActionDispatch::IntegrationTest
     assert_current_path new_client_visit_path(dni)
     fill_in :visit_description, with: 'una cama'
     fill_in :visit_duration, with: '2'
+    select Turn.last.to_s, from: 'Salida'
     click_on 'Guardar'
     assert_current_path visit_path(Visit.last)
   end

--- a/test/integration/admin_flow_test.rb
+++ b/test/integration/admin_flow_test.rb
@@ -27,7 +27,7 @@ class AdminFlowTest < ActionDispatch::IntegrationTest
     assert_current_path new_client_visit_path(dni)
     fill_in :visit_description, with: 'una cama'
     fill_in :visit_duration, with: '2'
-    select Turn.last.to_s, from: 'Salida'
+    select Turn.last.to_s, from: 'Turno'
     click_on 'Guardar'
     assert_current_path visit_path(Visit.last)
   end

--- a/test/models/day_test.rb
+++ b/test/models/day_test.rb
@@ -8,4 +8,8 @@ class DayTest < ActiveSupport::TestCase
   test 'each day is an active model object' do
     assert_kind_of ActiveModel::Conversion, calendar.first
   end
+
+  test 'calendars can be build with many weeks' do
+    assert_equal 14, Day.build(2).size
+  end
 end

--- a/test/models/turn_test.rb
+++ b/test/models/turn_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class TurnTest < ActiveSupport::TestCase
+  test 'cannot create a new turn for a past date' do
+    new_turn = Turn.new employee: employees(:pablo), at: 1.day.ago
+    refute new_turn.save
+    new_turn.at = Date.today
+    assert new_turn.save
+  end
+end

--- a/test/models/turn_test.rb
+++ b/test/models/turn_test.rb
@@ -7,4 +7,12 @@ class TurnTest < ActiveSupport::TestCase
     new_turn.at = Date.today
     assert new_turn.save
   end
+
+  test 'string representation is full of info' do
+    date = Date.parse('Monday')
+    turn = Turn.new employee: employees(:pablo),
+      at: date
+    assert_match /\(Pablo\)/, turn.to_s, 'display employee'
+    assert_match /#{date.day}/, turn.to_s, 'display date'
+  end
 end


### PR DESCRIPTION
The idea is that when you create a new visit you could:
- Add it to an existing turn, or
- Create a brand new turn for it

This two choices make it necessary to have a complex form (as the turn needs to be created before the visit) and we are not interested in having empty turns.

I'm adding some javascript to make it easier to manage while keeping it possible to use without any javascript at all.

The form submits all at once and only creates the turn if there is no turn selected.

I'm also adding missing validations for turn, localization, and string representations.

Also add the travis.yml (the part I dislike about travis so we will move to codeship ASAP). And use the gemified version of bootstrap as the other one do not work off-line.

@olvap can you review?

Resolves #28
